### PR TITLE
If a client sends a `LIST` command with a path that has multiple comp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 *.swo
 *.swp
+tests.log

--- a/mod_case.c
+++ b/mod_case.c
@@ -601,6 +601,9 @@ MODRET case_pre_cmd(cmd_rec *cmd) {
         return PR_DECLINED(cmd);
       }
 
+      /* Make sure we operate on a duplicate of the extracted path. */
+      path = pstrdup(cmd->tmp_pool, path);
+
     } else if (pr_cmd_cmp(cmd, PR_CMD_SITE_ID) == 0) {
       register unsigned int i;
 

--- a/t/lib/ProFTPD/Tests/Modules/mod_case.pm
+++ b/t/lib/ProFTPD/Tests/Modules/mod_case.pm
@@ -101,6 +101,11 @@ my $TESTS = {
     test_class => [qw(forking)],
   },
 
+  caseignore_list_no_matches => {
+    order => ++$order,
+    test_class => [qw(bug forking)],
+  },
+
   caseignore_nlst => {
     order => ++$order,
     test_class => [qw(forking)],
@@ -1848,6 +1853,135 @@ sub caseignore_list_filename_with_spaces {
       my $expected = {
         '.' => 1,
         '..' => 1,
+      };
+
+      my $ok = 1;
+      my $mismatch = '';
+      foreach my $name (keys(%$res)) {
+        unless (defined($expected->{$name})) {
+          $mismatch = $name;
+          $ok = 0;
+          last;
+        }
+      }
+
+      $self->assert($ok,
+        test_msg("Unexpected name '$mismatch' appeared in LIST data"));
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub caseignore_list_no_matches {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'case');
+
+  my $test_file = File::Spec->rel2abs("$tmpdir/test.txt");
+  create_test_file($setup, $test_file);
+
+  my $sub_dir = File::Spec->rel2abs("$tmpdir/sub.d/test.d");
+  create_test_dir($setup, $sub_dir);
+
+  my $subdir_file = File::Spec->rel2abs("$sub_dir/foo.txt");
+  create_test_file($setup, $subdir_file);
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'case:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+
+    IfModules => {
+      'mod_case.c' => {
+        CaseEngine => 'on',
+        CaseIgnore => 'on',
+        CaseLog => $setup->{log_file},
+      },
+
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      my $client = ProFTPD::TestSuite::FTP->new('127.0.0.1', $port);
+      $client->login($setup->{user}, $setup->{passwd});
+
+      my $conn = $client->list_raw('sub.d/test.d');
+      unless ($conn) {
+        die("Failed to LIST: " . $client->response_code() . " " .
+          $client->response_msg());
+      }
+
+      my $buf;
+      $conn->read($buf, 8192, 25);
+      eval { $conn->close() };
+
+      my $resp_code = $client->response_code();
+      my $resp_msg = $client->response_msg();
+      $self->assert_transfer_ok($resp_code, $resp_msg);
+
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# LIST:\n$buf\n";
+      }
+
+      # We have to be careful of the fact that readdir returns directory
+      # entries in an unordered fashion.
+      my $res = {};
+      my $lines = [split(/\n/, $buf)];
+      foreach my $line (@$lines) {
+        if ($line =~ /^\S+\s+\d+\s+\S+\s+\S+\s+.*?\s+(\S+)$/) {
+          $res->{$1} = 1;
+        }
+      }
+
+      my $expected = {
+        '.' => 1,
+        '..' => 1,
+        'foo.txt' => 1,
       };
 
       my $ok = 1;


### PR DESCRIPTION
…onents (sub-directories), _and_ no exact match is found, the module improperly changes the actual command argument, not a duplicate.

This leads to unexpected directory data being returned to the requesting client.